### PR TITLE
Add new engine api endpoints

### DIFF
--- a/alosi/engine_api.py
+++ b/alosi/engine_api.py
@@ -32,3 +32,15 @@ class EngineApi(object):
             self.base_url + '/score',
             json=dict(learner=learner, activity=activity, score=score)
         )
+
+    def bulk_update_mastery(self, data):
+        return self.client.put(
+            self.base_url + '/mastery/bulk_update',
+            json=data
+        )
+
+    def create_knowledge_component(self, **kwargs):
+        return self.client.post(
+            self.base_url + '/knowledge_component',
+            json=kwargs
+        )


### PR DESCRIPTION
Adds engine api for calling new endpoints:
* mastery update (https://github.com/harvard-vpal/adaptive-engine/pull/17, https://github.com/harvard-vpal/adaptive-engine/pull/20)
* create knowledge component (https://github.com/harvard-vpal/adaptive-engine/pull/21)

Examples:
```
api = alosi.engine_api.EngineApi(token=TOKEN)

# create knowledge component
data = dict(
    kc_id='kc2',
    name='my new kc',
    mastery_prior='0.5'
)
r = api.create_knowledge_component(**data)

# update mastery
data = [dict(
    learner=dict(
        user_id='learner5',
        tool_consumer_instance_guid='openedx.example.com'
    ),
    knowledge_component=dict(
        kc_id='sect_academic'
    ),
    value='0.1'
)]
r = api.bulk_update_mastery(data)
```