### PR TITLE
Add base api client

### DIFF
--- a/alosi/api_client.py
+++ b/alosi/api_client.py
@@ -1,0 +1,49 @@
+import requests
+
+
+class ApiClient:
+    """
+    Base class for api clients
+    """
+    api_path = None  # populated in subclass
+    trailing_slash = False  # override in subclass if needed
+
+    def __init__(self, host, token):
+        self.host = host
+        self.base_url = self.host + self.api_path
+        self.client = self._get_client(token)
+
+    @staticmethod
+    def _get_client(token=None):
+        """
+        Constructs a request.Session with auth header
+        :param token: API key
+        :rtype: requests.Session
+        """
+        client = requests.Session()
+        headers = {'Authorization': 'Token {}'.format(token)} if token else {}
+        client.headers.update(headers)
+        return client
+
+    def _absolute_url(self, path):
+        """
+        Construct absolute url given a relative api path
+        :param path: endpoint path (may or may not have starting slash)
+        :return: absolute url
+        :rtype: str
+        """
+        url = self.base_url + '/' + path.strip('/')
+        if self.trailing_slash:
+            url += '/'
+        return url
+
+    def request(self, method, path, **kwargs):
+        """
+        Makes a generic request using client and base url
+        :param method: HTTP method, e.g. 'GET'
+        :param path: endpoint path, e.g. 'activity' or '/knowledge_component'
+        :param kwargs: keyword arguments to pass to requests.request()
+        :rtype: requests.Response
+        """
+        url = self._absolute_url(path)
+        return self.client.request(method, url, **kwargs)

--- a/alosi/bridge_api.py
+++ b/alosi/bridge_api.py
@@ -1,26 +1,19 @@
-import requests
+from alosi.api_client import ApiClient
 
 
-class BridgeApi(object):
+class BridgeApi(ApiClient):
     """
     General API interface to bridge application
     """
+    api_path = "/api"
+    trailing_slash = True
 
     def __init__(self, host="http://localhost:8008", token=None):
-        self.host = host
-        self.base_url = "{}/api".format(self.host)
-        self.client = self.get_client(token)
-
-    @staticmethod
-    def get_client(token=None):
-        client = requests.Session()
-        headers = {'Authorization': 'Token {}'.format(token)} if token else {}
-        client.headers.update(headers)
-        return client
+        super().__init__(host, token)
 
     def get_collection(self, pk):
         return self.client.get(
-            "{}/collection/{}".format(self.base_url, pk)
+            self._absolute_url("collection/{}".format(pk))
         )
 
     def create_collection(self, **kwargs):
@@ -32,13 +25,13 @@ class BridgeApi(object):
             owner
         """
         return self.client.post(
-            self.base_url + '/collection/',
+            self._absolute_url('collection'),
             json=kwargs
         )
 
     def delete_collection(self, **kwargs):
         return self.client.delete(
-            self.base_url + '/collection/',
+            self._absolute_url('collection'),
             json=kwargs
         )
 
@@ -49,12 +42,12 @@ class BridgeApi(object):
 
     def create_activity(self, **kwargs):
         return self.client.post(
-            self.base_url + '/activity/',
+            self._absolute_url('activity'),
             json=kwargs
         )
 
     def delete_activity(self, **kwargs):
         return self.client.delete(
-            self.base_url + '/activity/',
+            self._absolute_url('activity'),
             json=kwargs
         )

--- a/alosi/engine_api.py
+++ b/alosi/engine_api.py
@@ -1,49 +1,43 @@
-import requests
+from alosi.api_client import ApiClient
 
 
-class EngineApi(object):
+class EngineApi(ApiClient):
     """
     General API interface to engine application
     """
+    api_path = "/api/v2"
 
     def __init__(self, host="http://localhost:8000", token=None):
-        self.host = host
-        self.base_url = "{}/api/v2".format(self.host)
-        self.client = self.get_client(token)
-
-    @staticmethod
-    def get_client(token=None):
-        client = requests.Session()
-        headers = {'Authorization': 'Token {}'.format(token)} if token else {}
-        client.headers.update(headers)
-        return client
+        super().__init__(host, token)
 
     def create_activity(self, **kwargs):
         return self.client.post(
-            self.base_url + '/activity',
+            self._absolute_url('activity'),
             json=kwargs
         )
 
     def recommend(self, learner=None, collection=None, sequence=None):
         return self.client.post(
+            self._absolute_url('activity/recommend'),
             self.base_url + '/activity/recommend',
             json=dict(learner=learner, collection=collection, sequence=sequence)
         )
 
     def submit_score(self, learner=None, activity=None, score=None):
         return self.client.post(
+            self._absolute_url('score'),
             self.base_url + '/score',
             json=dict(learner=learner, activity=activity, score=score)
         )
 
     def bulk_update_mastery(self, data):
         return self.client.put(
-            self.base_url + '/mastery/bulk_update',
+            self._absolute_url('mastery/bulk_update'),
             json=data
         )
 
     def create_knowledge_component(self, **kwargs):
         return self.client.post(
-            self.base_url + '/knowledge_component',
+            self._absolute_url('knowledge_component'),
             json=kwargs
         )


### PR DESCRIPTION
Add base api client, so that bridge and engine api clients can share some generic functionality like constructing urls, defining base url path, and making authenticated requests.